### PR TITLE
fix: remove unnecessary closing parens

### DIFF
--- a/traefik/dashboard.md
+++ b/traefik/dashboard.md
@@ -57,7 +57,7 @@ You can enable Traefik's dashboard by adding the following dynamic configuration
 http:
   routers:
     dashboard:
-      rule: Host(`<DOMAIN_FOR_TRAEFIK>`) && PathPrefix(`/dashboard`))
+      rule: Host(`<DOMAIN_FOR_TRAEFIK>`) && PathPrefix(`/dashboard`)
       service: api@internal
       middlewares:
         - auth


### PR DESCRIPTION
Removed an extra closing parens for `PathPrefix('/dashboard')`