### PR TITLE
Update openssh.mdx

### DIFF
--- a/src/content/docs/knowledge-base/server/openssh.mdx
+++ b/src/content/docs/knowledge-base/server/openssh.mdx
@@ -22,6 +22,7 @@ To validate your configuration, make sure the followings are set on your server.
 </Aside>
 
 <Steps>
+
 1. SSH Enabled
     Make sure SSH is enabled and you can connect to your server with SSH from your local machine with root user.
 
@@ -53,7 +54,9 @@ To validate your configuration, make sure the followings are set on your server.
 
     ````
 2. Root Login
-   Make sure `PermitRootLogin` is set to `yes` or `without-password` or `prohibit-password`  in `/etc/ssh/sshd_config` file.
+   Make sure that the following parameters are set in the `/etc/ssh/sshd_config` file:
+  - `PermitRootLogin` is set to `yes`, `without-password`, or `prohibit-password`.
+  - `PubkeyAuthentication` is set to `yes`.
 
     ```bash
     # Check the current value


### PR DESCRIPTION
Summary: This PR enhances the documentation by adding a crucial configuration check for SSH authentication. Specifically, it addresses the `PubkeyAuthentication` parameter in the `/etc/ssh/sshd_config` file, which, in some systems like Armbian, is disabled by default and can lead to authentication errors.

Problem: While troubleshooting, I encountered an issue where public key authentication failed due to the default setting of `PubkeyAuthentication` being disabled in `/etc/ssh/sshd_config`. This configuration, if unchecked, can cause unnecessary confusion and connection problems. Adding this check to the documentation will help users identify and resolve the issue quickly.

![image](https://github.com/user-attachments/assets/d9afc608-1796-4686-9e82-782b9e1968b9)


Similar issue: 
1. https://github.com/coollabsio/coolify/issues/3243
1. https://github.com/coollabsio/coolify/issues/1153
1. https://github.com/coollabsio/coolify/issues/3267
1. https://github.com/coollabsio/coolify/issues/1153

