### PR TITLE
Changed caution block link colour in dark mode

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -67,6 +67,9 @@ a[aria-current="true"] {
     @apply dark:text-black;
 }
 
+.starlight-aside--caution a {
+    @apply dark:text-black;
+}
 
 .starlight-aside--danger {
     @apply dark:bg-error border-error;


### PR DESCRIPTION
- Changed the link colour in caution blocks to black when using dark mode

Found bug on the following page:
https://coolify.io/docs/knowledge-base/docker/custom-commands