### PR TITLE
Add swap memory hint

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -55,6 +55,12 @@ To get started, you need a server, it can be a VPS, a Raspberry Pi, or any other
 - 2 GBs memory
 - 30+ GB of storage for the images.
 
+If you build on the same server and your builds are utilizing all available memory, 
+this may cause the server to become unresponsive. 
+To prevent this, consider 
+[enabling swap space](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04) 
+on your server (or paying for more resources).
+
 #### For Your Resources
 
 Choosing your server resources depends on your usage. If you are planning to run a lot of things, you should consider buying a server with more resources.


### PR DESCRIPTION
Addresses https://github.com/coollabsio/coolify/issues/2088 and my own experience:
I had a 2vCPU, 4Gb RAM instance on Hetzner.
Most of my NodeJS builds maxed out the instance's RAM, which was followed by the instance to desperately swap out memory, which wasn't enabled but still used 98% of CPU. This made the whole instance unresponsive.