### PR TITLE
fix: iframe aspect ratio on videos page

### DIFF
--- a/src/content/docs/videos.mdx
+++ b/src/content/docs/videos.mdx
@@ -1,20 +1,18 @@
 ---
 title: "Videos"
 head:
-  - tag: "meta"
-    attrs:
-        property: "og:title"
-        content: "A few videos of Coolify in action."
-description: "A few videos of Coolify in action."
-sidebar:
-  order: 3
+  - tag: style
+    content: |
+      .sl-markdown-content iframe {
+         aspect-ratio: 16 / 9;
+      }
 ---
 
-- Syntax: 1.5 hours long complete walkthrough
+#### Syntax: 1.5 hours long complete walkthrough
 
 <iframe
   width="560"
-  height="600"
+  height="315"
   src="https://www.youtube.com/embed/taJlPG82Ucw"
   title="YouTube video player"
   frameborder="0"
@@ -22,7 +20,7 @@ sidebar:
   allowfullscreen
 ></iframe>
 
-- WebdevCody: 6 minutes quick overview
+#### WebdevCody: 6 minutes quick overview
 
 <iframe
   width="560"
@@ -34,7 +32,7 @@ sidebar:
   allowfullscreen
 ></iframe>
 
-- DevelopedByEd: 20 minutes overview
+#### DevelopedByEd: 20 minutes overview
 
 <iframe
   width="560"
@@ -46,7 +44,7 @@ sidebar:
   allowfullscreen
 ></iframe>
 
-- Fireship video
+#### Fireship video
 
 <iframe
   width="560"
@@ -58,7 +56,7 @@ sidebar:
   allowfullscreen
 ></iframe>
 
-- MelkeyDev video
+#### MelkeyDev video
 
 <iframe
   width="560"

--- a/src/content/docs/videos.mdx
+++ b/src/content/docs/videos.mdx
@@ -3,7 +3,7 @@ title: "Videos"
 head:
   - tag: style
     content: |
-      .sl-markdown-content iframe {
+      .sl-markdown-content iframe[src^="https://www.youtube.com/embed/"] {
          aspect-ratio: 16 / 9;
       }
 ---


### PR DESCRIPTION
Fix the YouTube iframes on the videos page to use the 16x9 aspect ratio (wide) is what _most_ videos are using.

### Screenshots / Demo

Before & after gif:

![coolify_docs_before_after](https://github.com/user-attachments/assets/4ff4543a-66ac-498d-92c7-6980dd9f9714)
