### PR TITLE
Fix: Typo in Update aws.mdx

### DIFF
--- a/src/content/docs/knowledge-base/s3/aws.mdx
+++ b/src/content/docs/knowledge-base/s3/aws.mdx
@@ -43,7 +43,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 4. Go to User settings & create an `Access Key` in AWS Console.
 5. Add the `Access Key` and `Secret Key` in Coolify when you create a new S3 source.
    <Aside type="tip">
-     You need to use the S3 HTTP endpoit without the bucket name, for example,
+     You need to use the S3 HTTP endpoint without the bucket name, for example,
      `https://s3.eu-central-1.amazonaws.com`.
    </Aside>
 


### PR DESCRIPTION
Typo in the s3 knowledgebase
**endpoit**, should be **endpoint**.