### PR TITLE
Fix: Typo in introduction.mdx & installation.mdx

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -21,7 +21,7 @@ To get started, you need a server, it can be a VPS, a Raspberry Pi, or any other
 <Aside type="tip">
   If you don't have a server or server provider yet, we prefer to use Hetzner.
 
-  You can use our [referral link](https://coolify.io/hetzner). It will helps us to keep the project alive.
+  You can use our [referral link](https://coolify.io/hetzner). It will help us to keep the project alive.
 
 </Aside>
 

--- a/src/content/docs/knowledge-base/server/introduction.mdx
+++ b/src/content/docs/knowledge-base/server/introduction.mdx
@@ -48,7 +48,7 @@ You can connect any type of servers to Coolify. It could be a VPS, a Raspberry P
 <Aside type="tip">
 If you don't have a server or server provider yet, we prefer to use Hetzner.
 
-You can use our [referral link](https://coolify.io/hetzner). It will helps us to keep the project alive.
+You can use our [referral link](https://coolify.io/hetzner). It will help us to keep the project alive.
 
 </Aside>
 


### PR DESCRIPTION
Typo in :

1. `/src/content/docs/installation.mdx`
2. `/src/content/docs/knowledge-base/server/introduction.mdx`

**helps**, should be **help**