### PR TITLE
Add information about base route of api and fix route of healthcheck

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3093,7 +3093,7 @@ paths:
       security:
         -
           bearerAuth: []
-  /healthcheck:
+  /health:
     get:
       summary: Healthcheck
       description: 'Healthcheck endpoint.'

--- a/src/content/docs/api-reference/authorization.mdx
+++ b/src/content/docs/api-reference/authorization.mdx
@@ -3,14 +3,20 @@ title: Authorization
 head:
   - tag: "meta"
     attrs:
-        property: "og:title"
-        content: "How to authorize API requests in Coolify"
+      property: "og:title"
+      content: "How to authorize API requests in Coolify"
 description: "Learn how to authorize your API requests."
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
 
 API request requires a `Bearer` token in `Authorization` header, which could be generated from the UI.
+
+## Access
+
+The API can be accesed through `http://<ip>:8000/api`.
+
+With the exception of `/health` and `/feedback`, all routes are additionally prefixed with `/v1` resulting in the base rouce `http://<ip>:8000/api/v1`.
 
 ## Generate
 

--- a/src/content/docs/api-reference/authorization.mdx
+++ b/src/content/docs/api-reference/authorization.mdx
@@ -3,12 +3,12 @@ title: Authorization
 head:
   - tag: "meta"
     attrs:
-      property: "og:title"
-      content: "How to authorize API requests in Coolify"
+        property: "og:title"
+        content: "How to authorize API requests in Coolify"
 description: "Learn how to authorize your API requests."
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside } from '@astrojs/starlight/components';
 
 API request requires a `Bearer` token in `Authorization` header, which could be generated from the UI.
 


### PR DESCRIPTION
As already described here https://github.com/coollabsio/coolify/pull/3953 with the changes in the main repo, the information about the base route of the API was missing. Also the endpoint of healthcheck was wrong.