### PR TITLE
add example for health check endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3093,7 +3093,7 @@ paths:
       security:
         -
           bearerAuth: []
-  /healthcheck:
+  /health:
     get:
       summary: Healthcheck
       description: 'Healthcheck endpoint.'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -98,6 +98,10 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                static_image:
+                  type: string
+                  enum: ['nginx:alpine']
+                  description: 'The static image.'
                 install_command:
                   type: string
                   description: 'The install command.'
@@ -323,6 +327,10 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                static_image:
+                  type: string
+                  enum: ['nginx:alpine']
+                  description: 'The static image.'
                 install_command:
                   type: string
                   description: 'The install command.'
@@ -548,6 +556,10 @@ paths:
                 is_static:
                   type: boolean
                   description: 'The flag to indicate if the application is static.'
+                static_image:
+                  type: string
+                  enum: ['nginx:alpine']
+                  description: 'The static image.'
                 install_command:
                   type: string
                   description: 'The install command.'
@@ -4959,7 +4971,7 @@ components:
           type: boolean
         is_reachable:
           type: boolean
-        is_server_api_enabled:
+        is_sentinel_enabled:
           type: boolean
         is_swarm_manager:
           type: boolean
@@ -4981,11 +4993,11 @@ components:
           type: string
         logdrain_newrelic_license_key:
           type: string
-        metrics_history_days:
+        sentinel_metrics_history_days:
           type: integer
-        metrics_refresh_rate_seconds:
+        sentinel_metrics_refresh_rate_seconds:
           type: integer
-        metrics_token:
+        sentinel_token:
           type: string
         docker_cleanup_frequency:
           type: string

--- a/src/content/docs/api-reference/authorization.mdx
+++ b/src/content/docs/api-reference/authorization.mdx
@@ -3,14 +3,20 @@ title: Authorization
 head:
   - tag: "meta"
     attrs:
-        property: "og:title"
-        content: "How to authorize API requests in Coolify"
+      property: "og:title"
+      content: "How to authorize API requests in Coolify"
 description: "Learn how to authorize your API requests."
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
 
 API request requires a `Bearer` token in `Authorization` header, which could be generated from the UI.
+
+## Access
+
+The API can be accesed through `http://<ip>:8000/api`.
+
+With the exception of `/health` and `/feedback`, all routes are additionally prefixed with `/v1` resulting in the base rouce `http://<ip>:8000/api/v1`.
 
 ## Generate
 

--- a/src/content/docs/api-reference/authorization.mdx
+++ b/src/content/docs/api-reference/authorization.mdx
@@ -3,12 +3,12 @@ title: Authorization
 head:
   - tag: "meta"
     attrs:
-      property: "og:title"
-      content: "How to authorize API requests in Coolify"
+        property: "og:title"
+        content: "How to authorize API requests in Coolify"
 description: "Learn how to authorize your API requests."
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside } from '@astrojs/starlight/components';
 
 API request requires a `Bearer` token in `Authorization` header, which could be generated from the UI.
 

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -40,6 +40,7 @@ To get started, you need a server, it can be a VPS, a Raspberry Pi, or any other
 - Redhat based Linux distributions (CentOS, Fedora, Redhat, AlmaLinux, Rocky etc.)
 - SUSE based Linux distributions (SLES, SUSE, openSUSE, etc.)
 - Arch Linux
+- Alpine Linux
 - Raspberry Pi OS (Raspbian)
 
 ### Supported Architectures

--- a/src/content/docs/knowledge-base/health-checks.mdx
+++ b/src/content/docs/knowledge-base/health-checks.mdx
@@ -14,6 +14,8 @@ Health checks are important, but not mandatory for your application. It is a way
 
 If you set a health check, Coolify (and integrated proxy) will check the health of your application by sending a request to the health check endpoint.
 
+Make sure to configure the health check against the container internal endpoint (e.g. `http://localhost:3000`) and not against the domain (e.g. `https://mydomain.com`).
+
 The integrated proxy only forwards the request to your application if the health check is successful. If the health check fails, the proxy will return a 502 Bad Gateway error.
 
 ## What if I do not set a health check?

--- a/src/content/docs/knowledge-base/how-to/hetzner-loadbalancing.mdx
+++ b/src/content/docs/knowledge-base/how-to/hetzner-loadbalancing.mdx
@@ -17,7 +17,7 @@ Your application is growing, and you need to scale it. One of the most common wa
 
 In this guide, we will show you how to deploy a load-balanced application with Coolify on Hetzner Cloud. We will use two (or more) servers to host our application and a load balancer to distribute incoming traffic. We will also show you how to set up a database server if you need one.
 
-<Aside type="tip">The whole infractructure costs around ~15€ per month.</Aside>
+<Aside type="tip">The whole infrastructure costs around ~15€ per month.</Aside>
 
 ## Requirements
 


### PR DESCRIPTION
I think it's really helpful to mention that the health check has to be run against the containers internal endpoint.
I was getting nuts, trying to run the health check against my configured domain. 🥲 