### PR TITLE
fix(s3): image displayed again

### DIFF
--- a/src/content/docs/knowledge-base/s3/aws.mdx
+++ b/src/content/docs/knowledge-base/s3/aws.mdx
@@ -106,7 +106,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 4. Go to your user settings.
     ![4](../../../../assets/images/aws-s3/4-iam.jpeg)
 5. Create a new `Access Key`.
-    ![5](../../../../assets/images/aws-s3/5-iam.jpeg
+    ![5](../../../../assets/images/aws-s3/5-iam.jpeg)
 6. Set `Other` as use-case.
     ![6](../../../../assets/images/aws-s3/6-iam.jpeg)
 7. Copy the `Access Key` & `Secret Access Key`.


### PR DESCRIPTION
Hey, 

I was following the documentation in the s3 section and I noticed that one of the pictures was not rendered (cf attachment).

Just a missing '(' ;) 

Keep up the good work 💪 


![Screenshot 2024-11-11 at 21 47 38](https://github.com/user-attachments/assets/2f194ddf-bb57-4ac7-8174-3aaa40f96456)
