### PR TITLE
Update laravel.mdx

### DIFF
--- a/src/content/docs/applications/laravel.mdx
+++ b/src/content/docs/applications/laravel.mdx
@@ -246,6 +246,7 @@ http {
     server {
         # ...
         location ~ \.php$ {
+            fastcgi_pass 127.0.0.1:9000;
 +            fastcgi_buffer_size 8k;
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             include $!{nginx}/conf/fastcgi_params;


### PR DESCRIPTION
Add the `fastcgi_pass` line to the "**Increasing the NGINX buffer size for Inertia requests**" section to remove uncertainty as to whether it should be there or not. I hit this issue while installing a Laravel app and the result was a `.dms` file being download when navigation to the site URL.