### PR TITLE
Fix path for plausible analytics image

### DIFF
--- a/src/content/docs/services/plausible.mdx
+++ b/src/content/docs/services/plausible.mdx
@@ -8,7 +8,7 @@ head:
 description: "Here you can find the documentation for hosting Plausible Analytics with Coolify."
 ---
 
-![Plausible Analytics](/src/assets/images/services/plausible.svg)
+![Plausible Analytics](../../../assets/images/services/plausible.svg)
 
 ## What is Plausible Analytics?
 


### PR DESCRIPTION
Use relative path to image to fix the image on [coolify docs ](https://coolify.io/docs/services/plausible) as can be seen in image:

![image](https://github.com/user-attachments/assets/9339d443-341e-4547-9c9d-96150e273966)
