### PR TITLE
Adding --gpus as a supported Docker command options

### DIFF
--- a/src/content/docs/knowledge-base/docker/custom-commands.mdx
+++ b/src/content/docs/knowledge-base/docker/custom-commands.mdx
@@ -3,13 +3,12 @@ title: "Custom Commands"
 head:
   - tag: "meta"
     attrs:
-        property: "og:title"
-        content: "How to use custom commands for your Docker deployments with Coolify."
+      property: "og:title"
+      content: "How to use custom commands for your Docker deployments with Coolify."
 description: "A guide on how to use custom commands for your Docker deployments with Coolify."
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
-
+import { Aside, Steps } from "@astrojs/starlight/components";
 
 For deploying your resources, you can add custom options to the final docker command, which is used to run your container.
 
@@ -33,6 +32,7 @@ For deploying your resources, you can add custom options to the final docker com
 - `--init`
 - `--ulimit`
 - `--privileged`
+- `--gpus`
 
 ## Usage
 


### PR DESCRIPTION
`--gpus` was introduced as a supported option for the final Docker command in this release: https://github.com/coollabsio/coolify/pull/3878 but it was not added in the documentation as a supported option.