### PR TITLE
Add link to AWS S3 doc to improve visibility

### DIFF
--- a/src/content/docs/knowledge-base/s3/index.mdx
+++ b/src/content/docs/knowledge-base/s3/index.mdx
@@ -10,7 +10,7 @@ description: "A guide how to configure S3 compatible storage for Coolify."
 
 Currently supported S3 compatible storages are:
 
-- AWS
+- AWS (see [the AWS guide](./aws.mdx) for a detailed walkthrough)
 - DigitalOcean Spaces
 - MinIO
 - Cloudflare's R2


### PR DESCRIPTION
This adds a link to the S3 docs to help people discover the specific guide for AWS as it was quite hard to find previously