### PR TITLE
Replace bash with sh for docker exec commands

### DIFF
--- a/src/content/docs/knowledge-base/commands.mdx
+++ b/src/content/docs/knowledge-base/commands.mdx
@@ -15,7 +15,7 @@ You can use the following method to reset the root user's password, in case you 
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:reset-password"
+docker exec -ti coolify sh -c "php artisan root:reset-password"
 ```
 
 ## Root email change
@@ -24,7 +24,7 @@ You can change root user's email.
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:change-email"
+docker exec -ti coolify sh -c "php artisan root:change-email"
 ```
 
 ## Delete a stuck service
@@ -33,6 +33,6 @@ docker exec -ti coolify bash -c "php artisan root:change-email"
   Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan services:delete"
+docker exec -ti coolify sh -c "php artisan services:delete"
 ```
 

--- a/src/content/docs/services/wordpress.mdx
+++ b/src/content/docs/services/wordpress.mdx
@@ -30,7 +30,7 @@ It is used for creating websites, blogs, and applications.
 
 You can increase the upload size limit by following these steps:
 
-1. Open the `.htaccess` file through Coolify's Terminal (or through SSH, and docker exec -ti `container_id` /bin/bash)
+1. Open the `.htaccess` file through Coolify's Terminal (or through SSH, and docker exec -ti `container_id` /bin/sh)
 2. Add the following lines to the end of the file with `vi` or `nano`:
 
 ```


### PR DESCRIPTION
For commands using `docker exec`, update the documentation to suggest using `sh` inside the Coolify container instead of `bash`.

In my experience `bash` was not available inside the container and `sh` was so I had to use that instead. `sh` is sufficient for running the suggested commands so it should be in the documentation instead of `bash`.