### PR TITLE
change bash to sh in docker commands

### DIFF
--- a/src/content/docs/knowledge-base/commands.mdx
+++ b/src/content/docs/knowledge-base/commands.mdx
@@ -15,7 +15,7 @@ You can use the following method to reset the root user's password, in case you 
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:reset-password"
+docker exec -ti coolify sh -c "php artisan root:reset-password"
 ```
 
 ## Root email change
@@ -24,7 +24,7 @@ You can change root user's email.
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:change-email"
+docker exec -ti coolify sh -c "php artisan root:change-email"
 ```
 
 ## Delete a stuck service
@@ -33,6 +33,6 @@ docker exec -ti coolify bash -c "php artisan root:change-email"
   Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan services:delete"
+docker exec -ti coolify sh -c "php artisan services:delete"
 ```
 


### PR DESCRIPTION
Looks like bash is not available inside the Coolify container in 4.0.0.beta.380. But sh works.

Had the following conversation in terminal:
```
#:~# docker exec -ti coolify bash -c "php artisan root:reset-password"
OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
:~# docker exec -ti coolify sh -c "php artisan root:reset-password"
You are about to reset the root password.

```