### PR TITLE
Update tunnels (terminal mapping).mdx

### DIFF
--- a/src/content/docs/knowledge-base/cloudflare/tunnels.mdx
+++ b/src/content/docs/knowledge-base/cloudflare/tunnels.mdx
@@ -214,7 +214,7 @@ Let's say you configured the following `Public Hostnames` in Cloudflare:
 
 - `app.coolify.io` mapped to `localhost:8000`
 - `realtime.coolify.io` mapped to `localhost:6001`
-- `terminal.coolify.io` mapped to `localhost:6002`
+- `app.coolify.io/terminal/ws` mapped to `localhost:6002`
 
 After you installed Coolify, you need to add 3 lines your `.env` file, located in `/data/coolify/source` folder.
 


### PR DESCRIPTION
It solves the issue https://github.com/coollabsio/coolify/issues/4579 with broken WS connection from self-hosted instance.

I think the instruction `terminal.coolify.io mapped to localhost:6002` from [documentation](https://coolify.io/docs/knowledge-base/cloudflare/tunnels#setup-self-hosted-coolify) is misleading. To make requests to `terminal.coolify.io` you need to add `TERMINAL_HOST=terminal.coolify.io` to `/data/coolify/source/.env`. But this will take longer and won't work anyway, because `/terminal/ws` endpoint is bound to `app.coolify.io`.

Explaining why is in my [answer](https://github.com/coollabsio/coolify/issues/4579#issuecomment-2582930867) in issue.