### PR TITLE
Add missing information regarding SSL port in Cloudflare tunnel documentation

### DIFF
--- a/src/content/docs/knowledge-base/cloudflare/tunnels.mdx
+++ b/src/content/docs/knowledge-base/cloudflare/tunnels.mdx
@@ -183,7 +183,7 @@ To set up Coolify wildcard domains so that you can set `https://` in the url for
 
 3. Set SSL/TLS encryption mode to full (strict) in Cloudflare.
 
-4. Configure the tunnel to use `https` and then in the tunnel `Additional application settings -> TLS` set the Origin Server Name to be the root domain you want it to be (i.e - `yourdomain.com`)
+4. Configure the tunnel to use `https` and set the port to `443` instead of `80`. In the tunnel `Additional application settings -> TLS` set the Origin Server Name to be the root domain you want it to be (i.e - `yourdomain.com`)
 
     <Aside type="tip">
         You need to set the dropdown to be `https` before the TLS option appears


### PR DESCRIPTION
Currently the [Cloudflare tunnel](https://coolify.io/docs/knowledge-base/cloudflare/tunnels/) section of the documentation lacks a very important information regarding using SSL port 443 instead of port 80 when instructing users on how to turn on full HTTPS/TLS Setup.

This might cause problems like mentioned here: https://github.com/coollabsio/coolify/issues/4804