### PR TITLE
feat: gotenberg documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -352,6 +352,7 @@ export default defineConfig({
             { label: "Glance", link: "/services/glance" },
             { label: "Glances", link: "/services/glances" },
             { label: "Glitchtip", link: "/services/glitchtip" },
+            { label: "Gotenberg", link: "/services/gotenberg" },
             { label: "Grafana", link: "/services/grafana" },
             { label: "Grocy", link: "/services/grocy" },
             { label: "Heimdall", link: "/services/heimdall" },

--- a/src/content/docs/services/gotenberg.mdx
+++ b/src/content/docs/services/gotenberg.mdx
@@ -1,0 +1,27 @@
+---
+title: Gotenberg
+head:
+  - tag: "meta"
+    attrs:
+        property: "og:title"
+        content: "How to host Gotenberg with Coolify"
+description: "Here you can find the documentation for hosting Gotenberg with Coolify."
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+<Badge text="One-click setup." variant="note" size="large" />
+
+![Gotenberg](https://user-images.githubusercontent.com/8983173/130322857-185831e2-f041-46eb-a17f-0a69d066c4e5.png)
+
+## What is Gotenberg?
+
+Gotenberg provides a developer-friendly API to interact with powerful tools like Chromium and LibreOffice
+for converting numerous document formats (HTML, Markdown, Word, Excel, etc.) into PDF files, and more!
+
+Gotenberg **has no UI**. Head to the [documentation](https://gotenberg.dev/docs/getting-started/introduction) to learn how to interact with it 🚀.
+
+## Links
+
+- [Official Website ›](https://https://gotenberg.dev)
+- [GitHub ›](https://github.com/gotenberg/gotenberg)

--- a/src/content/docs/services/index.mdx
+++ b/src/content/docs/services/index.mdx
@@ -54,6 +54,7 @@ You can host ANY service with Coolify that could be containerized.
 - [Glance](/docs/services/glance) - All-in-one Home Server Dashboard.
 - [Glances](/docs/services/glances) - Cross-platform system monitoring tool.
 - [GlitchTip](/docs/services/glitchtip) - An open-source error tracking tool.
+- [Gotenberg](/docs/services/gotenberg) -  A Docker-powered stateless API for PDF files.
 - [Grafana](/docs/services/grafana) - The open platform for beautiful analytics and monitoring.
 - [Grocy](/docs/services/grocy) - A self-hosted groceries & household management solution for your home.
 - [Heimdall](/docs/services/heimdall) - An elegant solution to organize all your web applications.


### PR DESCRIPTION
Added documentations for Gotenberg, as discussed at https://github.com/coollabsio/coolify/pull/4759