### PR TITLE
Grammer error in Hetzner referral tip.

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -35,7 +35,7 @@ You need a server with SSH access. This can be:
 </Aside>
 
 <Aside type="tip">
-  If you don't have a server or server provider yet, we prefer to use Hetzner.
+  If you don’t have a server or server provider yet, we recommend using Hetzner.
 
   You can use our [referral link](https://coolify.io/hetzner). It will help us to keep the project alive.
 </Aside>


### PR DESCRIPTION
From: 
If you don’t have a server or server provider yet, we prefer to use Hetzner. 
To: 
If you don’t have a server or server provider yet, we recommend using Hetzner.