### PR TITLE
docs(applications): add preview deployments environment variables setup instructions

### DIFF
--- a/src/content/docs/applications/index.mdx
+++ b/src/content/docs/applications/index.mdx
@@ -134,6 +134,13 @@ If set to `true`, all PR's that are opened against the resource's configured bra
 
 You can manually deploy a Pull Request to a unique URL by clicking on the `Deploy` button on the Pull Request page.
 
+#### Changing Environment Variables for Preview Deployments
+
+To configure environment variables for preview deployments:
+1. Go to the `Environment Variables` menu in your Application Resource
+2. Click on the `Developer View` button
+3. Add your `Preview Deployments Environment Variables`
+
 ### Git Submodules
 
 If you are using git submodules, you can set this to `true`. `Enabled by default`.


### PR DESCRIPTION
After searching in docs and the Coolify app for changing env variables for preview deployments, I couldn't find clear instructions. This PR adds a step-by-step guide to help users quickly find this feature.

Changes made:
- Added clear numbered steps for setting up preview deployment env variables

