### PR TITLE
Fix a typo in installation.mdx

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -106,7 +106,7 @@ For the following things:
 ### 1. Quick Installation (Recommended)
 
 <Steps>
-1. **Prepare Your Servern**
+1. **Prepare Your Server**
    - Log in as the `root` user (non-root user is not fully supported yet [Non-root user guide](/docs/knowledge-base/server/non-root-user))
    - Configure SSH by following the [SSH Settings Configuration Guide](/docs/knowledge-base/server/openssh#ssh-settings-configuration)
    - Configure required firewall ports using the [Firewall Guide](/docs/knowledge-base/server/firewall) (if you are an advanced user you can have this configured differently)


### PR DESCRIPTION
Just fixing a typo. Docs stated `servern` instead of `server`

<img width="746" alt="image" src="https://github.com/user-attachments/assets/af775a6d-b6a2-42d5-894c-46c79f7c80d1" />
