### PR TITLE
docs(services): reword Nitropage service description

### DIFF
--- a/src/content/docs/services/nitropage.mdx
+++ b/src/content/docs/services/nitropage.mdx
@@ -7,7 +7,7 @@ head:
         content: "How to host Nitropage with Coolify"
   - tag: style
     content: |
-      .sl-markdown-content iframe[src^="https://nitropage.com"] {
+      .sl-markdown-content iframe[src^="https://nitropage.org"] {
          aspect-ratio: 16 / 9;
       }
 description: "Here you can find the documentation for hosting Nitropage with Coolify."
@@ -21,15 +21,25 @@ import { Badge } from '@astrojs/starlight/components';
 
 ## What is Nitropage?
 
-Nitropage is an extensible, drag-and-drop website builder based on SolidStart, completely free and open source.
+Nitropage is an extensible, visual website builder based on SolidStart, offering a growing library of versatile building blocks.
 
+## Features
+
+- [x] Reusable element **Presets** and **Layouts**
+- [x] Publishing workflow with **Revisions**
+- [x] Starter kit with dozens of Blueprints
+- [x] Multiple websites on a single instance
+- [x] Image optimization with **focal point** cropping
+- [x] API for your custom [SolidJS](https://www.solidjs.com/) page elements
+- [x] Powerful developer architecture with [Vite](https://vitejs.dev/)
+- [x] Automatic sitemap.xml and Atom-feed handling
 
 ## Video
 
 <iframe
   width="560"
   height="315"
-  src="https://nitropage.com/uploads/media/ia70mrjzii3ytqd33j78ao0u.mp4?ts=1709667029"
+  src="https://nitropage.org/uploads/media/ia70mrjzii3ytqd33j78ao0u.mp4?ts=1709667029"
   title="Nitropage"
   frameborder="0"
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -38,5 +48,5 @@ Nitropage is an extensible, drag-and-drop website builder based on SolidStart, c
 
 ## Links
 
-- [The official website ›](https://nitropage.com/?utm_source=coolify.io)
+- [The official website ›](https://nitropage.org/?utm_source=coolify.io)
 - [GitHub ›](https://codeberg.org/nitropage/nitropage?utm_source=coolify.io)


### PR DESCRIPTION
Just a couple rewordings, a new list with features and updated `.org` links (its the new main TLD).