### PR TITLE
docs(fix): duplicated http rule

### DIFF
--- a/src/content/docs/knowledge-base/traefik/wildcard-certificates.mdx
+++ b/src/content/docs/knowledge-base/traefik/wildcard-certificates.mdx
@@ -126,19 +126,20 @@ Redirect all subdomains to one application. You can use this option if you want 
 
 ```bash
 traefik.enable=true
-traefik.http.routers.<unique_router_name>.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.coolify.io`)
-traefik.http.routers.<unique_router_name>.entryPoints=https
-traefik.http.routers.<unique_router_name>.middlewares=gzip
-traefik.http.routers.<unique_router_name>.service=<unique_service_name>
+traefik.http.routers.<unique_router_name_https>.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.coolify.io`)
+traefik.http.routers.<unique_router_name_https>.entryPoints=https
+traefik.http.routers.<unique_router_name_https>.middlewares=gzip
+traefik.http.routers.<unique_router_name_https>.service=<unique_service_name>
+traefik.http.routers.<unique_router_name_https>.tls.certresolver=letsencrypt
 traefik.http.services.<unique_service_name>.loadbalancer.server.port=80
-traefik.http.routers.<unique_router_name>.tls=true
-traefik.http.routers.<unique_router_name>.tls.certresolver=letsencrypt
-traefik.http.routers.<unique_router_name>.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.coolify.io`)
-traefik.http.routers.<unique_router_name>.entryPoints=http
-traefik.http.routers.<unique_router_name>.middlewares=redirect-to-https
+traefik.http.routers.<unique_router_name_https>.tls=true
+
+traefik.http.routers.<unique_router_name_http>.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.coolify.io`)
+traefik.http.routers.<unique_router_name_http>.entryPoints=http
+traefik.http.routers.<unique_router_name_http>.middlewares=redirect-to-https
 ```
 
-> `traefik.http.routers.<unique_router_name>.tls.certresolver` should be the same as your `certresolver` name in Traefik proxy configuration, by default `letsencrypt`.
+> `traefik.http.routers.<unique_router_name_https>.tls.certresolver` should be the same as your `certresolver` name in Traefik proxy configuration, by default `letsencrypt`.
 
 > `traefik.http.services.<unique_service_name>.loadbalancer.server.port` should be the same as your application listens on. Port 80 if you use a static deployment.
 


### PR DESCRIPTION
There is a duplicate HTTP rule in these docs, and it should be in a different router name.

This line

```
traefik.http.routers.<unique_router_name>.rule=Host(`example.coolify.io`) && PathPrefix(`/`)
```

Should be use different router name