### PR TITLE
docs: fix formatting and example command in Downgrade docs

### DIFF
--- a/src/content/docs/downgrade.mdx
+++ b/src/content/docs/downgrade.mdx
@@ -22,7 +22,7 @@ If you have any issues with the latest version, you can simply downgrade to the 
  2. **Login to your server via SSH**
     - Login to your server via SSH and execute the following command:
     ```bash
-      curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.0.0-beta.277
+      curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash -s 4.0.0-beta.277
     ```
 
     Where `4.0.0-beta.277` is the version you want to downgrade to.

--- a/src/content/docs/downgrade.mdx
+++ b/src/content/docs/downgrade.mdx
@@ -15,12 +15,12 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 If you have any issues with the latest version, you can simply downgrade to the previous version. Here is how you can do it:
 
 <Steps>
- 1. Disable Auto Update
-    Login as the `root` user (or any user that is in the `root` (initial) team),
+ 1. **Disable Auto Update**
+    - Login as the `root` user (or any user that is in the `root` (initial) team),
     go to your `Settings` menu and disable the `Auto Update` feature.
 
- 2. Login to your server via SSH
-    Login to your server via SSH and execute the following command:
+ 2. **Login to your server via SSH**
+    - Login to your server via SSH and execute the following command:
     ```bash
       curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash -s 4.0.0-beta.277
     ```


### PR DESCRIPTION
## Summary

- Fix formatting for 'Login to your server via SSH' and 'Disable Auto Update' titles
- Add missing `sudo` prefix in example command as specified in the installation docs https://coolify.io/docs/installation. 

![image](https://github.com/user-attachments/assets/be4b1073-1bc3-4ec1-8c7c-aca5ef230ba9)
