### PR TITLE
fix: correct S3 documentation link to prevent 404

### DIFF
--- a/docs/databases/backups.md
+++ b/docs/databases/backups.md
@@ -67,4 +67,4 @@ mongodump --authenticationDatabase=admin --uri=<uri> --gzip --archive=<archive> 
 
 ## S3 Backups
 
-You can also define your own [S3 compatible](/knowledge-base/s3) storage to store your backups.
+You can also define your own [S3 compatible](/knowledge-base/s3/introduction) storage to store your backups.


### PR DESCRIPTION
https://coolify.io/docs/databases/backups

Fixed a broken link in the database backup documentation that was leading to a 404 error.

![docs_s3_issue](https://github.com/user-attachments/assets/abeeea86-bac4-4b85-b982-ef1cc0edb340)
_Broken link location_

<img width="1330" alt="broken_link" src="https://github.com/user-attachments/assets/f9003fff-7b4a-4b5e-bf52-c20c640f490c" />

_Leads to a non-existent page_

<img width="1330" alt="proposed_fix" src="https://github.com/user-attachments/assets/278b7793-725d-4f7d-a63a-6c101b315778" />

_Proposed fix_



