### PR TITLE
chore: update command lines to match the current container setup.

### DIFF
--- a/docs/knowledge-base/commands.md
+++ b/docs/knowledge-base/commands.md
@@ -9,7 +9,7 @@ You can use the following method to reset the root user's password, in case you 
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:reset-password"
+docker exec -ti coolify sh -c "php artisan root:reset-password"
 ```
 
 ## Root email change
@@ -18,7 +18,7 @@ You can change root user's email.
 Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan root:change-email"
+docker exec -ti coolify sh -c "php artisan root:change-email"
 ```
 
 ## Delete a stuck service
@@ -27,6 +27,6 @@ docker exec -ti coolify bash -c "php artisan root:change-email"
   Login to your server through SSH and execute the following command:
 
 ```bash
-docker exec -ti coolify bash -c "php artisan services:delete"
+docker exec -ti coolify sh -c "php artisan services:delete"
 ```
 


### PR DESCRIPTION
Hi 👋🏼 

I'm proposing the following change. It appears that bash is not available into the container failing with the following error:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
```

