### PR TITLE
Service.md github discussion link fix

### DIFF
--- a/docs/resource/contribute/service.md
+++ b/docs/resource/contribute/service.md
@@ -79,5 +79,5 @@ Services in Coolify are templates made from normal [docker-compose](https://docs
 
 If there's a service template you'd like to see in Coolify:
 
-1. Search [GitHub discussions](https://github.com/coollabsio/coolify/discussions/categories/new-service-integrations) for existing requests.
+1. Search [GitHub discussions](https://github.com/coollabsio/coolify/discussions/categories/service-template-requests) for existing requests.
 2. If the service has been requested, upvote it. If not, create a new request.


### PR DESCRIPTION
[Request a new service section](https://coolify.io/docs/resource/contribute/service) of the docs links to 
https://github.com/coollabsio/coolify/discussions/categories/new-service-integrations 
there are no discussions under that category so i changed link to
https://github.com/coollabsio/coolify/discussions/categories/service-template-requests
which seems to be the active category