### PR TITLE
add a note that this is not docker but npm

### DIFF
--- a/docs/knowledge-base/server/build-server.md
+++ b/docs/knowledge-base/server/build-server.md
@@ -4,7 +4,7 @@ description: "A guide on how to use a build server with Coolify"
 ---
 
 # Build Server
-You could have a build server to build your projects on instead of building them on the server where you host your resources.
+You could have a build server to build your projects on instead of building them on the server where you host your resources. This does not include Docker builds as much as npm build.
 
 This keeps the load separated, so it does not affect your application's performance.
 


### PR DESCRIPTION
Being new to the project, I assumed this meant I could run my Docker builds there as well. The reason I needed this is because when I install Supabase, it can really lock up the server. So I was hoping this could be a way to do it on another server, but then use it on the server I'm on. But I realized now I don't need to make it a build server. I could just use it as a normal other server.