### PR TITLE
Dockerfile deployment instructions for NextJS

### DIFF
--- a/docs/applications/nextjs.md
+++ b/docs/applications/nextjs.md
@@ -8,12 +8,24 @@ NextJS is a React framework that enables functionality such as server-side rende
 
 [Example repository.](https://github.com/coollabsio/coolify-examples/tree/main/nextjs)
 
-## Server build (NodeJS)
+## Deploy with Nixpacks
+
+### Server build (NodeJS)
 
 - Set `Build Pack` to `nixpacks`.
 
-## Static build (SPA)
+### Static build (SPA)
 
 - Set `Build Pack` to `nixpacks`.
 - Enable `Is it a static site?`.
 - Set `Output Directory` to `out`.
+
+## Deploy with Dockerfile
+
+If you are having problems with Nixpacks or want more control over the building stage, you can use a Dockerfile to deploy your NextJS application.
+
+### Prerequisites
+
+1. Set `Ports Exposes` field to `3000`.
+2. Create a `Dockerfile` in the root of your project and copy the content from the official [NextJS Repository](https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile).
+3. Set the Build Pack to `Dockerfile`.


### PR DESCRIPTION
The official [NextJS Docs](https://nextjs.org/docs/app/building-your-application/deploying#docker-image) already explain and provide a `Dockerfile` for dockerizing NextJS. Thus, we should include leverage this and include this in our own docs as well.

Therefore, I restructured the NextJS page, to include a `Deploy with Dockerfile` section, similar to the Jekyll page, with a link to the Dockerfile provided by Vercel.

![Bildschirmfoto am 2025-03-08 um 19 36 49](https://github.com/user-attachments/assets/2d6128f8-1096-468d-aca3-b2a89b9e06b5)
