### PR TITLE
Add warning about curl or wget requirement for health-checks

### DIFF
--- a/docs/knowledge-base/health-checks.md
+++ b/docs/knowledge-base/health-checks.md
@@ -15,3 +15,10 @@ The integrated proxy only forwards the request to your application if the health
 
 You get a warning next to your application's status. It is not mandatory, but it is recommended to set a health check.
 The integrated proxy will forward the request to your application without checking the health.
+
+::: warning  
+Health checks are performed from inside your container. To ensure they work correctly, you must install either `curl` or `wget`.  
+
+If health checks are enabled on a container without `curl` or `wget`, the container will always be marked as unhealthy, causing the deployment to fail.  
+:::
+

--- a/docs/knowledge-base/health-checks.md
+++ b/docs/knowledge-base/health-checks.md
@@ -16,9 +16,9 @@ The integrated proxy only forwards the request to your application if the health
 You get a warning next to your application's status. It is not mandatory, but it is recommended to set a health check.
 The integrated proxy will forward the request to your application without checking the health.
 
-::: warning  
-Health checks are performed from inside your container. To ensure they work correctly, you must install either `curl` or `wget`.  
+::: warning  Caution!
+Health checks run inside your container, so you need to have either `curl` or `wget` installed on your container. You can use an docker image that already includes `curl/wget` or add it to your Dockerfile yourself.
 
-If health checks are enabled on a container without `curl` or `wget`, the container will always be marked as unhealthy, causing the deployment to fail.  
+Without one of these packages, health checks will always fail and mark your container as unhealthy, which will cause the deployment to fail due to the failing health check.
 :::
 


### PR DESCRIPTION
As the title says. This is a minor addition about curl being a requirement for health-checks.