### PR TITLE
fix: 404 in raspberry-pi-os.md

### DIFF
--- a/docs/knowledge-base/how-to/raspberry-pi-os.md
+++ b/docs/knowledge-base/how-to/raspberry-pi-os.md
@@ -54,4 +54,4 @@ To run Coolify on a Raspberry Pi, you will need one of the following Raspberry P
 
 8. Once complete, insert the microSD card into your Raspberry Pi and power it on.
 
-9. After your Raspberry Pi boots up, proceed with the [Coolify installation](/installation#quick-installation-recommended).
+9. After your Raspberry Pi boots up, proceed with the [Coolify installation](/docs/get-started/installation#quick-installation-recommended).

--- a/docs/knowledge-base/how-to/raspberry-pi-os.md
+++ b/docs/knowledge-base/how-to/raspberry-pi-os.md
@@ -54,4 +54,4 @@ To run Coolify on a Raspberry Pi, you will need one of the following Raspberry P
 
 8. Once complete, insert the microSD card into your Raspberry Pi and power it on.
 
-9. After your Raspberry Pi boots up, proceed with the [Coolify installation](/docs/get-started/installation#quick-installation-recommended).
+9. After your Raspberry Pi boots up, proceed with the [Coolify installation](/get-started/installation#quick-installation-recommended).


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1bd02693-26fa-477d-8289-6532d99e30b1)

should go to
`/docs/get-started/installation#quick-installation-recommended`
but instead goes to
`/installation#quick-installation-recommended`