### PR TITLE
fix: miss mkdir folders in laravel.md

### DIFF
--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -318,6 +318,8 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /var/www/html
 
+RUN mkdir -p /var/www/html/storage /var/www/html/bootstrap/cache
+
 RUN chown -R unit:unit /var/www/html/storage bootstrap/cache && chmod -R 775 /var/www/html/storage
 
 COPY . .


### PR DESCRIPTION
storage and bootstrap/cache folders are necessary for a correct deployment.