### PR TITLE
2 Fixes: 1 - blank text in <code> on light mode hover and 2 - copy button on light mode

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -389,7 +389,7 @@ code:hover {
 
 /* Code block container styling */
 .vp-doc div[class*='language-'] {
-  position: static;
+  position: relative;
   margin: 0;
   background-color: var(--vp-c-bg-soft);
   border-radius: 10px;
@@ -771,7 +771,6 @@ pre.language-sh code:hover,
   }
 
   .vp-doc div[class*='language-'] {
-    position: relative;
     margin: 16px 0;
     background-color: var(--vp-code-bg) !important;
     border-radius: 8px;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -725,8 +725,8 @@ code:hover {
 div[class*='language-'] code:hover,
 pre[class*='language-'] code:hover {
   background-color: transparent !important;
-  color: var(--vp-code-color) !important;
-  -webkit-text-fill-color: var(--vp-code-color) !important;
+  color: inherit !important;
+  -webkit-text-fill-color: inherit !important;
   transform: none !important;
   box-shadow: none !important;
   border-color: transparent !important;


### PR DESCRIPTION
## Fix 1
There may be a better way to handle this (if hover effect is still wanted), but this fixes mouse hover making the text invisible on light mode.

### Before:

![Screen Recording 2025-03-21 at 11 10 41](https://github.com/user-attachments/assets/7071d009-cee2-4d8e-82d2-221984faac36)

### After:

![Screen Recording 2025-03-21 at 11 17 18](https://github.com/user-attachments/assets/90b5d376-6c67-4fbe-833c-6097ab4a8339)

## Fix 2
Fixes the copy buttons for code block being positioned at the top of the page on light mode

### Before:

![Screen Recording 2025-03-21 at 11 22 34](https://github.com/user-attachments/assets/093791b8-6fa2-40d3-a988-aef02c96658c)

### After:


![Screen Recording 2025-03-21 at 11 24 07](https://github.com/user-attachments/assets/ca44d356-1ebc-47cc-8116-d79ba262bbb5)
