### PR TITLE
docs(github-app): fixed English typo (unnecessary similar words usage)

### DIFF
--- a/docs/knowledge-base/git/github/github-app.md
+++ b/docs/knowledge-base/git/github/github-app.md
@@ -3,7 +3,7 @@ title: "Manually Setup GitHub App"
 ---
 
 # GitHub App
-This guide will show you how to use manually setup an existing Github App or how to change a currently configured one.
+This guide will show you how to manually setup an existing Github App or how to change a currently configured one.
 
 Since `4.0.0-beta.399` you are able to change all the Github App details inside Coolify.
 


### PR DESCRIPTION
Simply removed an unnecessary word, for english correctness.