### PR TITLE
Feat: Setting php.ini values in php-fpm.conf

### DIFF
--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -269,6 +269,31 @@ stdout_logfile=/var/log/worker-inertia-ssr.log
 '''
 ```
 
+### Persistent php.ini customizations
+
+If you want to customize settings from your php.ini file, you can easily do so by using the `php_admin_value` directive and appending them to your `php-fpm.conf` file like this:
+
+```toml
+"php-fpm.conf" = '''
+[www]
+listen = 127.0.0.1:9000
+user = www-data
+group = www-data
+listen.owner = www-data
+listen.group = www-data
+pm = dynamic
+pm.max_children = 50
+pm.min_spare_servers = 4
+pm.max_spare_servers = 32
+pm.start_servers = 18
+clear_env = no
+
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 60
+php_admin_value[max_input_time] = 60
+php_admin_value[post_max_size] = 256M
+'''
+```
 
 ## Deploy with Dockerfile and Nginx Unit
 

--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -142,6 +142,8 @@ pm.min_spare_servers = 4
 pm.max_spare_servers = 32
 pm.start_servers = 18
 clear_env = no
+php_admin_value[post_max_size] = 35M
+php_admin_value[upload_max_filesize] = 30M
 '''
 
 "nginx.template.conf" = '''
@@ -211,8 +213,6 @@ http {
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             include $!{nginx}/conf/fastcgi_params;
             include $!{nginx}/conf/fastcgi.conf;
-
-            fastcgi_param PHP_VALUE "upload_max_filesize=30M \n post_max_size=35M";
         }
      
         location ~ /\.(?!well-known).* {

--- a/docs/applications/symfony.md
+++ b/docs/applications/symfony.md
@@ -49,3 +49,29 @@ framework:
     trusted_proxies: "%env(TRUSTED_PROXIES)%"
     trusted_headers: ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix']
 ```
+
+### Persistent php.ini customizations
+
+If you want to customize settings from your php.ini file, you can easily do so by using the `php_admin_value` directive and appending them to your `php-fpm.conf` file like this:
+
+```toml
+"php-fpm.conf" = '''
+[www]
+listen = 127.0.0.1:9000
+user = www-data
+group = www-data
+listen.owner = www-data
+listen.group = www-data
+pm = dynamic
+pm.max_children = 50
+pm.min_spare_servers = 4
+pm.max_spare_servers = 32
+pm.start_servers = 18
+clear_env = no
+
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 60
+php_admin_value[max_input_time] = 60
+php_admin_value[post_max_size] = 256M
+'''
+```


### PR DESCRIPTION
Hey there! 👋 

Just a small improvement for people deploying PHP applications using coolify, so they can customize their php.ini settings easily inside the php-fpm.conf FPM worker config. Imho cleaner than setting it in the fastcgi_params.

I did not yet update the existing docs or examples. If I'm allowed to do that too, I'll also include this in my PR.

Thank you for all your work, you are doing an incredible job 🤗

Have a lovely day,
Tom