### PR TITLE
Add IDrive e2 to supported S3 storage options

### DIFF
--- a/content/docs/knowledge-base/s3/introduction.mdx
+++ b/content/docs/knowledge-base/s3/introduction.mdx
@@ -17,6 +17,7 @@ Currently supported S3 compatible storages are:
 - Wasabi hot cloud storage
 - Vultr
 - CloudPe Object Storage
+- IDrive e2
 
 Other's could work, but not tested yet. If you test it, please let us know.
 


### PR DESCRIPTION
Adds IDrive e2 to the list of supported S3-compatible storage providers in the documentation.