### PR TITLE
docs: add Payload CMS application guide

### DIFF
--- a/content/docs/applications/index.mdx
+++ b/content/docs/applications/index.mdx
@@ -31,6 +31,7 @@ Building Docker images can be resource-intensive. You can use a dedicated [build
 </Callout>
 
 
+
 ## Examples
 
 <Callout type="info">
@@ -49,6 +50,7 @@ Building Docker images can be resource-intensive. You can use a dedicated [build
 - [Next.js](/applications/nextjs)
 - [Nuxt](/applications/nuxt)
 - [Laravel](/applications/laravel)
+- [Payload CMS](/applications/payload-cms)
 - [Symfony](/applications/symfony)
 - [Ruby on Rails](/applications/rails)
 - [SvelteKit](/applications/svelte-kit)
@@ -232,4 +234,3 @@ For detailed guides on each build pack, see the [Build Packs section](/applicati
 Coolify uses [Nixpacks](https://nixpacks.com) by default, which automatically detects your application type and builds it accordingly. For most applications, you won't need to configure anything.
 
 </Callout>
-

--- a/content/docs/applications/meta.json
+++ b/content/docs/applications/meta.json
@@ -5,6 +5,7 @@
     "django",
     "jekyll",
     "laravel",
+    "payload-cms",
     "phoenix",
     "rails",
     "symfony",

--- a/content/docs/applications/payload-cms.mdx
+++ b/content/docs/applications/payload-cms.mdx
@@ -1,0 +1,77 @@
+---
+title: Payload CMS
+description: Deploy Payload CMS applications on Coolify as Git-connected Next.js apps with Dockerfile builds, databases, environment variables, and persistent uploads.
+---
+
+# Payload CMS
+
+Payload CMS is a TypeScript-first headless CMS that runs as part of your application code. Deploy it on Coolify as an application from a Git repository, not as a one-click service template.
+
+Payload projects usually need their own collections, access control, admin customization, plugins, and storage configuration. Because of that, the recommended Coolify flow is to deploy the project source with a Dockerfile or Nixpacks and attach the database and storage resources your project uses.
+
+## Deploy with Dockerfile
+
+### Requirements
+
+1. Create or connect the database that your Payload project uses, such as PostgreSQL or MongoDB.
+2. Add the database connection string and Payload secrets to your application environment variables.
+3. Set `Build Pack` to `Dockerfile`.
+4. Set `Ports Exposes` to the port your Payload app listens on, commonly `3000`.
+5. Configure persistent uploads with external object storage or a persistent volume.
+
+### Environment Variables
+
+Payload templates commonly read database and secret values from environment variables. Add the variables that match your project configuration in the Coolify UI.
+
+```bash
+DATABASE_URL=postgresql://user:password@host:5432/payload
+PAYLOAD_SECRET=replace-with-a-long-random-secret
+NEXT_PUBLIC_SERVER_URL=https://payload.example.com
+```
+
+If your project uses MongoDB, set the MongoDB connection string expected by your adapter instead of `DATABASE_URL`.
+
+### Dockerfile
+
+Payload 3 runs on Next.js, so the standard Next.js standalone Dockerfile pattern works well. Make sure your `next.config` enables standalone output before building the image.
+
+```ts
+// next.config.ts
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  output: 'standalone',
+}
+
+export default nextConfig
+```
+
+Then add a production Dockerfile to your repository, or adapt the official Next.js Dockerfile example for your package manager.
+
+### Uploads
+
+Do not rely on the container filesystem for production uploads unless you configure persistent storage. For most production Payload projects, use an object storage plugin such as S3, DigitalOcean Spaces, or another compatible provider.
+
+If you use local uploads, create a persistent storage mount in Coolify and point your Payload upload directory to that mounted path.
+
+### Migrations
+
+If your Payload project uses migrations, run them as part of your deployment process before the new container starts serving traffic. You can use Coolify's pre-deployment or post-deployment commands for project-specific migration commands.
+
+## Deploy with Nixpacks
+
+Use Nixpacks when your Payload project follows the standard Node.js build and start flow and does not require a custom Dockerfile.
+
+1. Set `Build Pack` to `nixpacks`.
+2. Set the install, build, and start commands if Nixpacks does not detect them correctly.
+3. Set `Ports Exposes` to the app port.
+4. Add the same database, secret, and upload storage environment variables.
+
+For projects that need precise image contents, native dependencies, or standalone Next.js output control, prefer the Dockerfile build pack.
+
+## Related Guides
+
+- [Next.js](/applications/nextjs)
+- [Dockerfile Build Pack](/applications/build-packs/dockerfile)
+- [Environment Variables](/knowledge-base/environment-variables)
+- [Persistent Storage](/knowledge-base/persistent-storage)


### PR DESCRIPTION
## Summary

Adds Payload CMS as an application/framework guide instead of a one-click service entry. This follows the maintainer feedback on #597 that Payload should be deployed as an application because the project needs its own source code, Dockerfile/build config, database adapter, secrets, and uploads storage.

## What changed

- adds `content/docs/applications/payload-cms.mdx` with Dockerfile and Nixpacks deployment guidance
- documents database env vars, `PAYLOAD_SECRET`, standalone Next.js output, uploads storage, and migrations
- links the page from the Applications overview and `meta.json` navigation

## Validation

- `git diff --check`
- markdown sanity check for frontmatter, balanced fences, related guide links, and `meta.json` navigation
- verified related guide target files exist on the `next` docs tree

Resolves coollabsio/coolify#2346
/claim coollabsio/coolify#2346
/claim #2346