### PR TITLE
docs: Add token to docker login example

### DIFF
--- a/content/docs/applications/ci-cd/github/actions.mdx
+++ b/content/docs/applications/ci-cd/github/actions.mdx
@@ -154,7 +154,7 @@ If pushing to a private registry, authenticate it on your server so it can pull 
 Run one of these commands on your server's terminal (based on the registry):
 
 - **Docker Hub**: `docker login`
-- **GitHub Container Registry (GHCR)**: `docker login ghcr.io -u USERNAME --password-stdin`
+- **GitHub Container Registry (GHCR)**: `echo $GH_TOKEN | docker login ghcr.io -u $USERNAME --password-stdin`
 
 For other registries, refer to their documentation.
 


### PR DESCRIPTION
Somewhat aligned the docker login example with [the GitHub docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). This makes it more clear for beginners that a token is needed.