### PR TITLE
Ensure storage and bootstrap cache are writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN --mount=type=cache,target=/root/.bun \
     --mount=type=cache,target=/app/docs/.vitepress/cache \
     bun run build
 
-# Stage 2: NGINX Unprivileged Setup (1.29.3-alpine-slim, ARM64)
-FROM nginxinc/nginx-unprivileged:1.29.3-alpine-slim AS final
+# Stage 2: NGINX Unprivileged Setup 
+FROM nginxinc/nginx-unprivileged:1.30.1-alpine-slim AS final
 
 # Set working directory for NGINX and copy built files from the build stage
 WORKDIR /usr/share/nginx/html

--- a/docs/applications/laravel.md
+++ b/docs/applications/laravel.md
@@ -63,6 +63,10 @@ cmd = '/assets/start.sh'
 "start.sh" = '''
 #!/bin/bash
 
+# Ensure storage and bootstrap cache are writable by www-data
+chown -R www-data:www-data /app/storage /app/bootstrap/cache
+chmod -R 775 /app/storage /app/bootstrap/cache
+
 # Transform the nginx configuration
 node /assets/scripts/prestart.mjs /assets/nginx.template.conf /etc/nginx.conf
 
@@ -119,6 +123,7 @@ stderr_logfile=/var/log/worker-phpfpm.log
 [program:worker-laravel]
 process_name=%(program_name)s_%(process_num)02d
 command=bash -c 'exec php /app/artisan queue:work --sleep=3 --tries=3 --max-time=3600'
+user=www-data
 autostart=true
 autorestart=true
 stopasgroup=true


### PR DESCRIPTION
I have run in some permission issues with the `laravel.log` file. 

`The exception occurred while attempting to log: The stream or file "/app/storage/logs/laravel.log" could not be opened in append mode: Failed to open stream: Permission denied`

In my case, the worker created the log file and the application failed, since the log file was under the root user. I fixed it by updating the `nixpacks.toml` with the correct permissions.

