### PR TITLE
fix(docs): correct typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ TODOs.md
 .env
 
 package-lock.json
+pnpm-lock.yaml
 
 ui-sample

--- a/content/docs/applications/ci-cd/github/setup-app.mdx
+++ b/content/docs/applications/ci-cd/github/setup-app.mdx
@@ -216,7 +216,7 @@ Creating apps on github slightly varies for personal accounts and organizations 
 2. Enter homepage url for your app (this can be anything)
 
 <ZoomImage src="/docs/images/applications/ci-cd/github/setup-app/23.webp" />
-3. Scrol down till you see the "**Post Installation**" section
+3. Scroll down till you see the "**Post Installation**" section
 4. Enter Setup URL: `https://coolboxy.shadowarcanist.internal/webhooks/source/github/install?source=a8000cg0g0ogcc0ggkk8ow4k`
 
 5. Enable the option `Redirect on Update`
@@ -234,7 +234,7 @@ Creating apps on github slightly varies for personal accounts and organizations 
 8. Enable the option `Enable SSL verification`
 
 <ZoomImage src="/docs/images/applications/ci-cd/github/setup-app/24.webp" />
-9. Scrol down till you see the "**Permissions**" section
+9. Scroll down till you see the "**Permissions**" section
 10. Set Access to `Read-only` for `Contents`
 11. Set Access to `Read and write` for `Pull Requests` (Only needed if you plan to use Preview deployments feature)
 12. Set Access to `Read-only` for `Email addresses`
@@ -248,7 +248,7 @@ On the screenshot above for permissions section we have hidden lot of Permission
 
 
 <ZoomImage src="/docs/images/applications/ci-cd/github/setup-app/25.webp" />
-13. Scrol down till you see the "**Subscribe to events**" section
+13. Scroll down till you see the "**Subscribe to events**" section
 14. Enable the option `Push`
 15. Enable the option `Pull requests` (Only needed if you plan to use Preview deployments feature)
 16. Select the option `Only on this account` (Prevents others from installing our Github app to their github accounts)
@@ -262,7 +262,7 @@ On the screenshot above for permissions section we have hidden lot of Permission
 20. Save the `client secret` somewhere safe (we have to enter this on Coolify later)
 
 <ZoomImage src="/docs/images/applications/ci-cd/github/setup-app/28.webp" />
-21. Scrol down till you see the "**Private keys**" section
+21. Scroll down till you see the "**Private keys**" section
 22. Click the `Generate a private key` button (this will automatically download the private key as a `.pem` file)
 
 <ZoomImage src="/docs/images/applications/ci-cd/github/setup-app/29.webp" />

--- a/content/docs/knowledge-base/delete-user.mdx
+++ b/content/docs/knowledge-base/delete-user.mdx
@@ -33,7 +33,7 @@ The root team or root user cannot be deleted.
 </Callout>
 
 
-Coolify iterate over all the teams of a user and decide of the followings:
+Coolify iterates over all the teams of a user and decides on the following:
 
 ### The user is alone in the team
 

--- a/content/docs/knowledge-base/domains.mdx
+++ b/content/docs/knowledge-base/domains.mdx
@@ -91,7 +91,7 @@ And App B becomes unhealthy, requests to `/api` will be routed to App A instead.
 </Callout>
 
 
-Read more about how Coolifys proxies read and intepret the health of your resources in our [Health Checks page](/knowledge-base/health-checks).
+Read more about how Coolifys proxies read and interpret the health of your resources in our [Health Checks page](/knowledge-base/health-checks).
 
 ## Catch Multiple Domains
 

--- a/content/docs/knowledge-base/server/multiple-servers.mdx
+++ b/content/docs/knowledge-base/server/multiple-servers.mdx
@@ -27,7 +27,7 @@ When you configure (or already configured) an application, you selected a server
 
 Any additional servers must be set in the `Servers` menu, simply by clicking on it.
 
-Now everytime you redeploy, restart or stop the application, the action will be done on all servers.
+Now every time you redeploy, restart, or stop the application, the action will be done on all servers.
 
 If the deploy needs a build process, it will be executed on the main server (or on the build server if you have one). The deploy process will upload the built image to the Docker Registry and only after all other servers will be notified to pull and deploy this image.
 


### PR DESCRIPTION
This pull request contains several small corrections to documentation files, primarily fixing typos and improving the clarity of instructions. No functional or structural changes have been made.

Documentation typo and clarity fixes:

* Corrected multiple instances of "Scrol" to "Scroll" in the GitHub app setup instructions in `github/setup-app.mdx`. [[1]](diffhunk://#diff-e2ece75502248f1302d5e9264330ace657dae6b81a79812bf5a586b99a0ecd21L219-R219) [[2]](diffhunk://#diff-e2ece75502248f1302d5e9264330ace657dae6b81a79812bf5a586b99a0ecd21L237-R237) [[3]](diffhunk://#diff-e2ece75502248f1302d5e9264330ace657dae6b81a79812bf5a586b99a0ecd21L251-R251) [[4]](diffhunk://#diff-e2ece75502248f1302d5e9264330ace657dae6b81a79812bf5a586b99a0ecd21L265-R265)
* Improved grammar and clarity in the team iteration explanation in `delete-user.mdx`.
* Fixed spelling in the health check explanation in `domains.mdx` ("intepret" to "interpret").
* Corrected "everytime" to "every time" and improved punctuation in the multiple servers documentation in `multiple-servers.mdx`.