### PR TITLE
fix(docs): fixed dokuwiki logo path

### DIFF
--- a/content/docs/services/dokuwiki.mdx
+++ b/content/docs/services/dokuwiki.mdx
@@ -7,7 +7,7 @@ category: "Documentation"
 icon: "/docs/images/services/dokuwiki-logo.png"
 ---
 
-<ZoomImage src="https://www.dokuwiki.org/lib/tpl/dokuwiki/images/logo.png" alt="DokuWiki" />
+<ZoomImage src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Dokuwiki_logo.svg/60px-Dokuwiki_logo.svg.png" alt="DokuWiki" />
 
 ## What is DokuWiki?
 


### PR DESCRIPTION

<img width="423" height="226" alt="image" src="https://github.com/user-attachments/assets/d329d4af-dbaf-45bd-87d2-85b60bb7c47c" />

<img width="879" height="424" alt="image" src="https://github.com/user-attachments/assets/03858b51-a641-422b-809d-acf5e309ed5e" />
