### PR TITLE
docs(services): clarify LiteLLM model storage

### DIFF
--- a/content/docs/services/litellm.mdx
+++ b/content/docs/services/litellm.mdx
@@ -13,6 +13,12 @@ icon: "/docs/images/services/litellm-logo.svg"
 
 LiteLLM is an open-source LLM Gateway to manage authentication, loadbalancing, and spend tracking across 100+ LLMs. All in the OpenAI format.
 
+## Configuration
+
+Coolify stores LiteLLM model configuration in the service database by default. This keeps model settings available across redeployments without requiring you to manage an external config file.
+
+The one-click service also generates a stable salt value for LiteLLM so stored model records continue to work after the service is recreated or updated.
+
 ## Screenshots
 
 <br />


### PR DESCRIPTION
## Summary

- Adds a LiteLLM configuration note for Coolify's one-click service.
- Documents that model configuration is stored in the service database by default.
- Mentions the generated stable salt used to keep stored model records usable across service updates.

Related service PR: coollabsio/coolify#10548

## Testing

- Ran git diff --check.
- Could not run the docs type check locally because node_modules is not installed in this checkout.