### PR TITLE
docs(service): add LibreDB Studio service page

### DIFF
--- a/content/docs/services/libredb-studio.mdx
+++ b/content/docs/services/libredb-studio.mdx
@@ -1,0 +1,25 @@
+---
+title: "LibreDB Studio"
+description: "Modern, AI-powered open-source SQL IDE for PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis."
+category: "Database"
+---
+
+# LibreDB Studio
+
+## What is LibreDB Studio?
+
+LibreDB Studio is an MIT-licensed, AI-powered open-source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser. It ships as a single Docker container with no external database required.
+
+## Links
+
+- [Official website](https://libredb.org?utm_source=coolify.io)
+- [GitHub](https://github.com/libredb/libredb-studio?utm_source=coolify.io)
+- [Documentation](https://github.com/libredb/libredb-studio#readme?utm_source=coolify.io)
+
+## Features
+
+- Connect to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis
+- AI-assisted query generation and explanation
+- Single container deploy — no external database required
+- Auto-generated admin/user passwords and JWT secret
+- Persistent SQLite storage via Docker volume


### PR DESCRIPTION
Adds documentation for LibreDB Studio, proposed in https://github.com/coollabsio/coolify/pull/10756

- content/docs/services/libredb-studio.mdx — service documentation

Links:
- GitHub: https://github.com/libredb/libredb-studio
- Website: https://libredb.org/