### PR TITLE
feat(services): port Buzz service from main

### DIFF
--- a/content/docs/services/all.mdx
+++ b/content/docs/services/all.mdx
@@ -303,6 +303,10 @@ Complete directory of all one-click services available in Coolify, organized by 
 - [Transmission](/services/transmission) - Fast, easy, and free BitTorrent client.
 - [Yamtrack](/services/yamtrack) - Self-hosted music scrobble database.
 
+## Messaging
+
+- [Buzz](/services/buzz) - Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.
+
 ## Monitoring
 
 - [Beszel](/services/beszel) - Lightweight server monitoring hub with historical data, docker stats, and alerts.

--- a/content/docs/services/buzz.mdx
+++ b/content/docs/services/buzz.mdx
@@ -1,0 +1,30 @@
+---
+title: "Buzz"
+description: "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay."
+og:
+  description: "Deploy Buzz on Coolify for human and AI agent collaboration, channels, workflows, Git events, and an auditable Nostr event log."
+category: "Messaging"
+icon: "/docs/images/services/buzz-logo.svg"
+---
+
+# Buzz
+
+<ZoomImage src="/docs/images/services/buzz-logo.svg" alt="Buzz logo" />
+
+## What is Buzz?
+
+Buzz is a self-hostable workspace where humans and AI agents share the same rooms. Messages, reactions, workflow steps, review approvals, and Git events are stored as signed events on a Nostr relay you own.
+
+The Coolify service deploys Buzz together with PostgreSQL, Redis, and MinIO. It also configures persistent storage for the relay's Git repositories, database, Redis, and uploaded media.
+
+## Connect a Buzz client
+
+After deploying the service, copy its public URL and change the scheme from `https://` to `wss://`. Use that WebSocket URL as the relay URL in a [Buzz desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io) or set it through the client's `BUZZ_RELAY_URL` environment variable.
+
+For example, a Coolify service URL of `https://buzz.example.com` corresponds to the relay URL `wss://buzz.example.com`.
+
+## Links
+
+- [GitHub](https://github.com/block/buzz?utm_source=coolify.io)
+- [Architecture](https://github.com/block/buzz/blob/main/ARCHITECTURE.md?utm_source=coolify.io)
+- [Latest desktop client](https://github.com/block/buzz/releases/latest?utm_source=coolify.io)

--- a/public/images/services/buzz-logo.svg
+++ b/public/images/services/buzz-logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 466 309">
+  <style>
+    .mark { fill: #231e1e; }
+    @media (prefers-color-scheme: dark) {
+      .mark { fill: #d7d72e; }
+    }
+  </style>
+  <defs>
+    <mask id="bee-mask">
+      <circle cx="91.7" cy="154.5" r="91.7" fill="white"/>
+      <circle cx="374.3" cy="154.5" r="91.7" fill="white"/>
+      <rect x="128" y="0" width="210" height="309" rx="34" fill="white"/>
+      <circle cx="193.3" cy="84.4" r="27" fill="black"/>
+      <circle cx="276" cy="84.4" r="27" fill="black"/>
+      <rect x="166.3" y="157.2" width="136.9" height="38.3" rx="5" fill="black"/>
+      <rect x="166.9" y="235.1" width="136.2" height="37.6" rx="5" fill="black"/>
+    </mask>
+  </defs>
+  <rect class="mark" width="466" height="309" mask="url(#bee-mask)"/>
+</svg>

--- a/src/generated/services.json
+++ b/src/generated/services.json
@@ -169,6 +169,13 @@
     "category": "Development"
   },
   {
+    "name": "Buzz",
+    "slug": "buzz",
+    "icon": "/docs/images/services/buzz-logo.svg",
+    "description": "Workspace where humans and AI agents collaborate on a self-hosted Nostr relay.",
+    "category": "Messaging"
+  },
+  {
     "name": "Calcom",
     "slug": "calcom",
     "icon": "/docs/images/services/calcom-logo.svg",


### PR DESCRIPTION
## Summary

Buzz was added on `main` in fa299376 after `next` diverged, so it doesn't exist on `next` yet. This PR brings it into `next` before the rework is merged into `main`, so the merge doesn't drop it.

- Adds `content/docs/services/buzz.mdx` and `public/images/services/buzz-logo.svg` from `main`.
- Adds the `# Buzz` heading after the frontmatter, matching other service pages on `next`.
- Regenerates `src/generated/services.json` and `content/docs/services/all.mdx` with `bun run generate:services`, which adds the new **Messaging** category.

The other part of fa299376, moving Cockpit from Administration to CMS, is already on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbfU7ucfMHk5NUpMjL6vbL