### PR TITLE
docs(mcp): use Coolify Cloud domain in examples

### DIFF
--- a/content/docs/mcp/clients/claude-code.mdx
+++ b/content/docs/mcp/clients/claude-code.mdx
@@ -12,7 +12,7 @@ Claude Code can connect directly to Coolify's Streamable HTTP MCP endpoint.
 Run this command from a terminal. Replace the URL and token:
 
 ```sh
-claude mcp add --transport http coolify https://coolify.shadowarcanist.com/mcp \
+claude mcp add --transport http coolify https://app.coolify.io/mcp \
   --header "Authorization: Bearer 67|abcthisisa123dummytoken"
 ```
 

--- a/content/docs/mcp/clients/cursor.mdx
+++ b/content/docs/mcp/clients/cursor.mdx
@@ -12,7 +12,7 @@ Cursor supports remote MCP servers over Streamable HTTP.
 1. Open Cursor settings.
 2. Open **Tools & Integrations** and select **MCP**.
 3. Add a new remote MCP server.
-4. Set the URL to `https://coolify.shadowarcanist.com/mcp`.
+4. Set the URL to `https://app.coolify.io/mcp`.
 5. Set the Authorization header to `Bearer 67|abcthisisa123dummytoken`.
 6. Save the server and enable it.
 

--- a/content/docs/mcp/clients/other-clients.mdx
+++ b/content/docs/mcp/clients/other-clients.mdx
@@ -10,7 +10,7 @@ Any MCP client that supports remote Streamable HTTP servers can connect to Cooli
 ## Required configuration
 
 ```yaml
-server_url: https://coolify.shadowarcanist.com/mcp
+server_url: https://app.coolify.io/mcp
 transport: streamable-http
 authorization: Bearer 67|abcthisisa123dummytoken
 ```

--- a/content/docs/mcp/setup.mdx
+++ b/content/docs/mcp/setup.mdx
@@ -20,12 +20,12 @@ An MCP client can use every operation allowed by its token. Store the token in t
 
 ## Example values
 
-Use your own instance URL and token when following this guide:
+This guide uses Coolify Cloud in its examples. If you use a self-hosted Coolify instance, replace `app.coolify.io` with your instance's domain in every URL, and use your own token:
 
 <Callout type="info" title="Example data">
 
-- **Coolify URL:** `https://coolify.shadowarcanist.com`
-- **MCP endpoint:** `https://coolify.shadowarcanist.com/mcp`
+- **Coolify URL:** `https://app.coolify.io`
+- **MCP endpoint:** `https://app.coolify.io/mcp`
 - **API token:** `67|abcthisisa123dummytoken`
 
 </Callout>
@@ -54,10 +54,10 @@ MCP must also be enabled in the current team's settings. Open team settings and 
 </Tab>
 <Tab value="API">
 
-Use a `root` API token to enable or disable the instance endpoint:
+On a self-hosted instance, use a `root` API token to enable or disable the instance endpoint. Replace the example URL with your instance's domain:
 
 ```sh
-export COOLIFY_URL="https://coolify.shadowarcanist.com"
+export COOLIFY_URL="https://coolify.example.com"
 export COOLIFY_ROOT_TOKEN="67|abcthisisa123dummytoken"
 
 curl --fail-with-body --request POST \
@@ -89,7 +89,7 @@ Coolify displays the complete token only once. Copy it into the client's secret 
 MCP endpoint URL:
 
 ```txt
-https://coolify.shadowarcanist.com/mcp
+https://app.coolify.io/mcp
 ```
 
 </Step>
@@ -99,7 +99,7 @@ https://coolify.shadowarcanist.com/mcp
 
 Configure the client with:
 
-- **URL:** `https://coolify.shadowarcanist.com/mcp`
+- **URL:** `https://app.coolify.io/mcp`
 - **Transport:** Streamable HTTP
 - **Authorization:** `Bearer 67|abcthisisa123dummytoken`
 


### PR DESCRIPTION
## Summary

This brings the change from `main` commit 70dcfbff into `next`. That commit switched the MCP examples to the Coolify Cloud domain, but it edited `integrations/mcp.mdx`, and `next` has since split that page into `content/docs/mcp/*`. The commit can't be cherry-picked, so this PR applies the same change to the new pages.

- Replaces the example domain `coolify.shadowarcanist.com` with `app.coolify.io` in `setup.mdx` and the Claude Code, Cursor, and other-clients pages.
- Rewrites the intro to the example values: the guide uses Coolify Cloud, and self-hosted users should replace `app.coolify.io` with their own domain.
- **Differs from `main`:** the instance enable/disable API example in **Set up MCP > Enable MCP > API** uses `https://coolify.example.com` instead of `app.coolify.io`. That tab is self-hosted only (the page tells Cloud users to skip it), so a Cloud URL next to a `root` token would be misleading.

`main`'s troubleshooting note is not needed: the troubleshooting page on `next` doesn't contain the endpoint URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbfU7ucfMHk5NUpMjL6vbL