### PR TITLE
docs(start): fill in self-hosted next-steps links

### DIFF
--- a/content/docs/start-with-self-hosted.mdx
+++ b/content/docs/start-with-self-hosted.mdx
@@ -704,15 +704,15 @@ Once Coolify is running, start by deploying something on the same server where C
       links: [
         {
           title: 'Add and validate servers',
-          href: 'shadow-to-do',
+          href: '/core/infrastructure/servers/add-server',
         },
         {
           title: 'Build server',
-          href: 'shadow-to-do',
+          href: '/core/infrastructure/servers/build-servers',
         },
         {
           title: 'Multiple servers',
-          href: 'shadow-to-do',
+          href: '/core/infrastructure/scaling/multi-server-deployments',
         },
       ],
     },
@@ -723,15 +723,15 @@ Once Coolify is running, start by deploying something on the same server where C
       links: [
         {
           title: 'Upgrade',
-          href: 'shadow-to-do',
+          href: '/core/instance-management/update',
         },
         {
           title: 'Downgrade',
-          href: 'shadow-to-do',
+          href: '/core/instance-management/downgrade',
         },
         {
           title: 'Uninstallation',
-          href: 'shadow-to-do',
+          href: '/core/instance-management/uninstallation',
         },
       ],
     },


### PR DESCRIPTION
## Summary

The "Grow beyond one server" and "Ongoing operations" link groups on the self-hosted getting-started page (`content/docs/start-with-self-hosted.mdx`) used `shadow-to-do` placeholder hrefs. This PR points them at their existing pages:

| Link | Target |
|---|---|
| Add and validate servers | `/core/infrastructure/servers/add-server` |
| Build server | `/core/infrastructure/servers/build-servers` |
| Multiple servers | `/core/infrastructure/scaling/multi-server-deployments` |
| Upgrade | `/core/instance-management/update` |
| Downgrade | `/core/instance-management/downgrade` |
| Uninstallation | `/core/instance-management/uninstallation` |

These targets match the existing redirects in `nginx/redirects.conf` (for example `/upgrade`, `/downgrade`, `/uninstallation`, `knowledge-base/server/build-server`, `knowledge-base/server/multiple-servers`).

The remaining `shadow-to-do` strings in the repo are `src` values on commented-out `ZoomableImage` screenshot placeholders, not links, so this PR doesn't touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz97z9JATXMaZvwbRMjp2G
