### PR TITLE
docs(notifications): add Gotify channel documentation

### DIFF
--- a/content/docs/core/notifications/channels/gotify.mdx
+++ b/content/docs/core/notifications/channels/gotify.mdx
@@ -1,0 +1,63 @@
+---
+title: Gotify
+description: Send Coolify push notifications through a self-hosted Gotify server.
+---
+
+# Gotify
+
+Coolify sends notifications to your own [Gotify](https://gotify.net/) server using a server URL and an application token created in that Gotify instance.
+
+## Create a Gotify application
+
+Before configuring Coolify, you need a running Gotify server and at least one client (the Gotify Android app or web UI) signed in to receive messages.
+
+<Steps>
+<Step>
+
+### Open the Apps page
+
+Sign in to your Gotify server's web UI and open the **Apps** tab.
+
+</Step>
+<Step>
+
+### Create an application
+
+1. Select **Create Application**.
+2. Enter a name, such as `Coolify`.
+3. Save the application and copy its **token**.
+
+The application token identifies Coolify as the sender. Gotify shows the token once; you can regenerate it later from the same page if needed.
+
+</Step>
+</Steps>
+
+<Callout type="warning" title="Protect the application token">
+Store the Gotify application token as a secret. If it is exposed, delete or regenerate the application in Gotify and update Coolify.
+</Callout>
+
+---
+
+## Configure Coolify
+
+1. Open **Notifications > Gotify**.
+2. Enter the **Server URL** (for example `https://gotify.example.com`, no trailing path) and the **Application Token**, then select **Save**.
+3. Turn on **Enabled**.
+4. Under **Notification Settings**, select the events to send through Gotify.
+5. Select **Send Test Notification**.
+
+Confirm that the test arrives on a client connected to your Gotify server before selecting more events.
+
+---
+
+## Troubleshoot Gotify delivery
+
+If the test does not arrive:
+
+1. Confirm that **Server URL** points to your Gotify server's base URL and is reachable from where Coolify runs (no firewall blocking outbound requests).
+2. Confirm that **Application Token** came from an application created in that same Gotify server, not a client/user token.
+3. Confirm that at least one client (app or browser) is signed in and connected to the Gotify server.
+4. Check the Gotify server's own logs for rejected or failed requests.
+5. If you regenerated the application token, save the new value in Coolify and test again.
+
+See [Notification events](/core/notifications/events) for the trigger behind each event setting.

--- a/content/docs/core/notifications/channels/meta.json
+++ b/content/docs/core/notifications/channels/meta.json
@@ -6,6 +6,7 @@
     "telegram",
     "slack-mattermost",
     "pushover",
+    "gotify",
     "webhook"
   ]
 }

--- a/content/docs/core/notifications/events.mdx
+++ b/content/docs/core/notifications/events.mdx
@@ -5,7 +5,7 @@ description: Choose which deployment, backup, scheduled task, container, and ser
 
 # Notification events
 
-Coolify lets you choose events separately for email, Discord, Telegram, Slack, Pushover, and webhook notifications. Open **Notifications**, select a channel, then use **Notification Settings** to change that channel's event selections.
+Coolify lets you choose events separately for email, Discord, Telegram, Slack, Pushover, Gotify, and webhook notifications. Open **Notifications**, select a channel, then use **Notification Settings** to change that channel's event selections.
 
 Changing an event for one channel does not change the other channels.
 

--- a/content/docs/core/notifications/overview.mdx
+++ b/content/docs/core/notifications/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Understand how Coolify sends team notifications through email, Discord, Telegram, Slack, Mattermost, Pushover, and webhooks.
+description: Understand how Coolify sends team notifications through email, Discord, Telegram, Slack, Mattermost, Pushover, Gotify, and webhooks.
 ---
 
 # Notifications overview
@@ -27,6 +27,7 @@ Coolify stores notification settings for the current team. Team members with per
 | Telegram | A bot API token and chat ID | [Telegram](/core/notifications/channels/telegram) |
 | Slack or Mattermost | A Slack-compatible incoming webhook URL | [Slack & Mattermost](/core/notifications/channels/slack-mattermost) |
 | Pushover | A Pushover user key and application API token | [Pushover](/core/notifications/channels/pushover) |
+| Gotify | A self-hosted Gotify server URL and application token | [Gotify](/core/notifications/channels/gotify) |
 | Webhook | An HTTP or HTTPS endpoint that accepts JSON `POST` requests | [Webhook notifications](/core/notifications/channels/webhook/setup) |
 
 You can enable more than one channel. Event selections are independent for each channel.


### PR DESCRIPTION
## Summary

Adds documentation for the Gotify notification channel: a new guide page (`content/docs/core/notifications/channels/gotify.mdx`), a sidebar entry, and mentions in the notifications overview and events pages.

Written to match the code PR: coollabsio/coolify#11746 (`feat(notifications): add Gotify notification channel`).

## Related

Related to #383 (`docs(notifications): add gotify notification provider docs`, opened by @YaRissi, stalled since 2026-05 with merge conflicts and no review). This PR is a fresh, up-to-date rewrite targeting the current `next` rather than a rebase of that branch.

## AI Assistance

This page was drafted with Claude Code, based on the actual implementation in coollabsio/coolify#11746 (verified locally against a running instance), then reviewed and type-checked (`bun run types:check`) before opening this PR.

## Testing

- `bun run types:check` passes
- Verified the page renders correctly via `bun run dev`
<img width="1280" height="1956" alt="gotify-docs-page" src="https://github.com/user-attachments/assets/19d00cfb-0378-43ad-92d1-8da2bf28dab3" />
